### PR TITLE
Use ES5 functions instead of arrow functions on orbit controls

### DIFF
--- a/components/orbit-controls/index.js
+++ b/components/orbit-controls/index.js
@@ -38,7 +38,7 @@ AFRAME.registerComponent('orbit-controls', {
 
     oldPosition = new THREE.Vector3();
 
-    el.sceneEl.addEventListener('enter-vr', () => {
+    el.sceneEl.addEventListener('enter-vr', function() {
       if (!AFRAME.utils.device.checkHeadsetConnected() &&
           !AFRAME.utils.device.isMobile()) { return; }
       this.controls.enabled = false;
@@ -49,7 +49,7 @@ AFRAME.registerComponent('orbit-controls', {
       }
     });
 
-    el.sceneEl.addEventListener('exit-vr', () => {
+    el.sceneEl.addEventListener('exit-vr', function() {
       if (!AFRAME.utils.device.checkHeadsetConnected() &&
           !AFRAME.utils.device.isMobile()) { return; }
       this.controls.enabled = true;
@@ -60,10 +60,10 @@ AFRAME.registerComponent('orbit-controls', {
     });
 
     document.body.style.cursor = 'grab';
-    document.addEventListener('mousedown', () => {
+    document.addEventListener('mousedown', function() {
       document.body.style.cursor = 'grabbing';
     });
-    document.addEventListener('mouseup', () => {
+    document.addEventListener('mouseup', function() {
       document.body.style.cursor = 'grab';
     });
 


### PR DESCRIPTION
I was using the orbit control package and was not able to do `react-scripts build` because Uglify in `react-scripts build` can't parse the generated ES6 code. Was wondering if you would kindly accept my PR to change them back to ES5 syntax. Thanks!