### PR TITLE
Remove cursor on body

### DIFF
--- a/components/orbit-controls/index.js
+++ b/components/orbit-controls/index.js
@@ -44,14 +44,6 @@ AFRAME.registerComponent('orbit-controls', {
     el.sceneEl.addEventListener('enter-vr', this.onEnterVR); 
     el.sceneEl.addEventListener('exit-vr', this.onExitVR);
 
-    document.body.style.cursor = 'grab';
-    document.addEventListener('mousedown', () => {
-      document.body.style.cursor = 'grabbing';
-    });
-    document.addEventListener('mouseup', () => {
-      document.body.style.cursor = 'grab';
-    });
-
     this.target = new THREE.Vector3();
     el.getObject3D('camera').position.copy(this.data.initialPosition);
   },


### PR DESCRIPTION
Not necessary. A-frame handles the cursor style by it's own for the canvas object. Second thing is, if you use a-scene as embedded.