### PR TITLE
[geometry-merger] Keeping colors when material color is used

### DIFF
--- a/components/geometry-merger/README.md
+++ b/components/geometry-merger/README.md
@@ -25,6 +25,7 @@ For either `geometry-merger` or `buffer-geometry-merger` components:
 | Property         | Description                                                                                                                                                                                                                                               | Default Value |
 | --------         | -----------                                                                                                                                                                                                                                               | ------------- |
 | preserveOriginal | Whether to remove the now-merged child goemetry or keep in scene graph. It can be useful to keep the original child entities' geometries and set their `material="visible: false"` so that we can still interact with them with colliders and raycasters. | false         |
+| materialColors | Whether to use material colors in merged geometries for the faces of the final mesh, so that colors of the faces in this final mesh resemble the colors of the original entities when they were material colors. | true |
 
 #### Members
 

--- a/components/geometry-merger/index.js
+++ b/components/geometry-merger/index.js
@@ -4,7 +4,8 @@ if (!THREE.BufferGeometryUtils) {
 
 AFRAME.registerComponent('geometry-merger', {
   schema: {
-    preserveOriginal: {default: false}
+    preserveOriginal: {default: false},
+    materialColors: {default: true}
   },
 
   init: function () {
@@ -32,6 +33,14 @@ AFRAME.registerComponent('geometry-merger', {
         self.geometry.vertices.length,
         self.geometry.vertices.length + mesh.geometry.vertices.length - 1
       ];
+
+      // If material color applied to all faces, copy colors to faces
+      if (self.data.materialColors && (mesh.material.vertexColors === THREE.NoColors)) {
+        let color = mesh.material.color;
+        for ( const face of mesh.geometry.faces) {
+          face.color.set( color );
+        };
+      };
 
       // Merge. Use parent's matrix due to A-Frame's <a-entity>(Group-Mesh) hierarchy.
       mesh.parent.updateMatrix();


### PR DESCRIPTION
When merged entities are using material colors for their whole mesh (as opposed to vertex or faces colors), the resulting merged mesh doesn't show those colors. This patch addes a new property, materialColors, that when true, copies the material color (if vertexColors is THREE.NoColors) to the faces in the mesh of the entity to be merged, so that when merged, the corresponding faces keep the color. This allows the resulting mesh to have the coloring appearence of the original entities, and is quite useful when AFrame materials with a single color are used.