### PR TITLE
[buffer-geometry-merger] Fix to work with dynamic elements

### DIFF
--- a/components/geometry-merger/index.js
+++ b/components/geometry-merger/index.js
@@ -50,13 +50,20 @@ AFRAME.registerComponent('buffer-geometry-merger', {
 
   init: function () {
     var geometries = [];
+    var self = this;
 
-    this.el.sceneEl.object3D.updateMatrixWorld()
+    this.el.object3D.updateMatrixWorld()
     this.el.object3D.traverse(function (mesh) {
       if (mesh.type !== 'Mesh' || mesh.el === self.el) { return; }
-      mesh.geometry.applyMatrix(mesh.matrixWorld);
-      geometries.push(mesh.geometry.clone());
-      mesh.parent.remove(mesh);
+      var geometry = mesh.geometry.clone();
+      var currentMesh = mesh;
+      while (currentMesh !== self.el.object3D) {
+        geometry.applyMatrix(currentMesh.parent.matrix);
+        currentMesh = currentMesh.parent;
+      }
+      geometries.push(geometry);
+      // Remove mesh if not preserving.
+      if (!self.data.preserveOriginal) { mesh.parent.remove(mesh); }
     });
 
     const geometry = THREE.BufferGeometryUtils.mergeBufferGeometries(geometries);


### PR DESCRIPTION
The `buffer-geometry-merger`, as it was, does not work when you inject (using JavaScript) some components in a DOM subtree, and then apply it to merge all geometries in the subtree. See details in
https://stackoverflow.com/questions/59110629/a-frame-buffer-geometry-merger-seems-to-shift-entities-in-some-cases/59513236#59513236

This fix bakes the matrixes of the components into the cloned geometries, so that when they are merged into a single one, it is correctly positioned. I also change the updating of the world matrixes for all the scene, to the updating of the world matrixes for the intended subtree.

In the process, I also added a definition for `self`, which was used in the code, but not defined.