### PR TITLE
Added documentation for templaterendered event

### DIFF
--- a/components/template/README.md
+++ b/components/template/README.md
@@ -67,6 +67,12 @@ through the `data` property. If both are defined, they will be combined.
 If `type` is not defined and we are loading it from an external template, then
 the component will render raw HTML.
 
+### Events
+
+| Event            | Description                                                                                                                  |
+|------------------|----------------------------------------|
+| templaterendered | Emitted when the template is rendered  |
+
 ### Script Tag Type
 
 If loading from a script tag, it must have the `type` attribute defined. The


### PR DESCRIPTION
Recently used the template component, and did a convoluted fix to emit an event when it was rendered. Turned out there was already a way to do this in the component. Would it be helpful to add it to the documentation?