### PR TITLE
[aframe-state-component] Preserve booleans in generateExpression

### DIFF
--- a/components/state/src/lib/index.js
+++ b/components/state/src/lib/index.js
@@ -22,12 +22,14 @@ const WHITESPACE_RE = /\s/g;
 const STATE_SELECTOR_RE = /([=&|!?:+-])(\s*)([\(]?)([A-Za-z][\w_-]*)/g;
 const ROOT_STATE_SELECTOR_RE = /^([\(]?)([A-Za-z][\w_-]*)/g;
 const ITEM_RE = /state\["item"\]/g;
+const BOOLEAN_RE = /state\["(true|false)"\]/g;
 const STATE_STR = 'state';
 function generateExpression (str) {
   str = str.replace(DOT_NOTATION_RE, '["$1"]');
   str = str.replace(ROOT_STATE_SELECTOR_RE, '$1state["$2"]');
   str = str.replace(STATE_SELECTOR_RE, '$1$2$3state["$4"]');
   str = str.replace(ITEM_RE, 'item');
+  str = str.replace(BOOLEAN_RE, '$1');
   return str;
 }
 module.exports.generateExpression = generateExpression;

--- a/components/state/tests/index.test.js
+++ b/components/state/tests/index.test.js
@@ -1352,6 +1352,13 @@ suite('generateExpression', function () {
     assert.equal(lib.generateExpression('item.id + item.bar'), 'item["id"] + item["bar"]');
   });
 
+  test('preserves booleans', () => {
+    assert.equal(lib.generateExpression('true'), 'true');
+    assert.equal(lib.generateExpression('false'), 'false');
+    assert.equal(lib.generateExpression('a && true'), 'state["a"] && true');
+    assert.equal(lib.generateExpression('a && true || false'), 'state["a"] && true || false');
+  });
+
   test('preserves string whitespace', () => {
     assert.equal(lib.generateExpression('foo + "a b c"'), 'state["foo"] + "a b c"');
   });


### PR DESCRIPTION
This PR adds the ability to use `true` and `false` in bindings.
If the binding contains `true` or `false` it will not be replaced with `state['true']` or `state['false']`.

Resolves #269 

I added a regex in `generateExpression` to replace `state['true']` and `state['false']` with the boolean. The same behavior like the `state['item']` to `item`.
I also added a test to ensure the replacement is handled correctly.