### PR TITLE
readme example to reflect latest package version #

### DIFF
--- a/components/orbit-controls/README.md
+++ b/components/orbit-controls/README.md
@@ -61,7 +61,7 @@ Install and use by directly including the [browser files](dist):
 <head>
   <title>My A-Frame Scene</title>
   <script src="https://aframe.io/releases/0.9.0/aframe.min.js"></script>
-  <script src="https://unpkg.com/aframe-orbit-controls@1.2.0/dist/aframe-orbit-controls.min.js"></script>
+  <script src="https://unpkg.com/aframe-orbit-controls@1.3.0/dist/aframe-orbit-controls.min.js"></script>
   <script src="https://unpkg.com/aframe-supercraft-loader@1.1.3/dist/aframe-supercraft-loader.js"></script>
 </head>
 


### PR DESCRIPTION
side note (not fixed but FYI) the npm badge from the top of readme currently links to a very old npm repo, not from ngokevin or supermedium: https://www.npmjs.com/package/aframe-orbit-controls-component