### PR TITLE
[state]: bind-for and bind-item unsubscribe fix

### DIFF
--- a/components/state/src/bind-for.js
+++ b/components/state/src/bind-for.js
@@ -299,6 +299,10 @@ AFRAME.registerComponent('bind-for', {
     } else {
       this.onStateUpdateNaive();
     }
+  },
+
+  remove: function () {
+    this.el.sceneEl.systems.state.unsubscribe(this);
   }
 });
 
@@ -387,5 +391,9 @@ AFRAME.registerComponent('bind-item', {
 
     propertyMap[this.id] = this.data;
     lib.parseKeysToWatch(this.keysToWatch, this.data, true);
+  },
+
+  remove: function () {
+    this.el.sceneEl.systems.state.unsubscribe(this);
   }
 });

--- a/components/state/src/index.js
+++ b/components/state/src/index.js
@@ -166,7 +166,9 @@ AFRAME.registerSystem('state', {
   },
 
   unsubscribe: function (component) {
-    this.subscriptions.splice(this.subscriptions.indexOf(component), 1);
+    var i = this.subscriptions.indexOf(component);
+    if (i > -1)
+      this.subscriptions.splice(i, 1);
   },
 
   /**


### PR DESCRIPTION
Bug fixed: bind-for and bind-item are not unsubscribing from state.
Bug fixed: if no component found the last subscriber will be removed in unsubscribe method.
Source issue: #278 