### PR TITLE
Removed tracked-controls dependencies and replaced them with adding the component when a controller is detected.

### DIFF
--- a/components/haptics/index.js
+++ b/components/haptics/index.js
@@ -26,8 +26,8 @@ AFRAME.registerComponent('haptics', {
 
     this.callPulse = function () { self.pulse(); };
 
-    var doInit = function (gamepad) {
-      self.gamepad = gamepad;
+    var doInit = function () {
+      self.gamepad = self.el.components['tracked-controls'].controller;
       if (self.gamepad.gamepad) {
         // WebXR.
          self.gamepad = self.gamepad.gamepad;
@@ -39,10 +39,10 @@ AFRAME.registerComponent('haptics', {
 
     // There may exist a tracked-controls when this component is initialized
     if (this.el.components['tracked-controls'] && this.el.components['tracked-controls'].controller) {
-      doInit(this.el.components['tracked-controls'].controller);
+      doInit();
     } else {
       this.el.addEventListener('controllerconnected', function init () {
-        doInit(self.el.components['tracked-controls'].controller);
+        doInit();
       });
     }
   },

--- a/components/haptics/index.js
+++ b/components/haptics/index.js
@@ -8,8 +8,6 @@ if (typeof AFRAME === 'undefined') {
  * Haptics component for A-Frame.
  */
 AFRAME.registerComponent('haptics', {
-  dependencies: ['tracked-controls'],
-
   schema: {
     actuatorIndex: {default: 0},
     dur: {default: 100},
@@ -28,7 +26,8 @@ AFRAME.registerComponent('haptics', {
 
     this.callPulse = function () { self.pulse(); };
 
-    if (this.el.components['tracked-controls'].controller) {
+    // There may exist a tracked-controls when this component is initialized
+    if (this.el.components['tracked-controls'] && this.el.components['tracked-controls'].controller) {
       this.gamepad = this.el.components['tracked-controls'].controller;
 
       if (this.gamepad.gamepad) {
@@ -41,6 +40,10 @@ AFRAME.registerComponent('haptics', {
       this.addEventListeners();
     } else {
       this.el.addEventListener('controllerconnected', function init () {
+        // If no tracked-controls yet exists, add it here
+        if (!self.el.components['tracked-controls']) {
+          self.el.setAttribute('tracked-controls', {});
+        }
         setTimeout(function () {
           self.gamepad = self.el.components['tracked-controls'].controller;
 

--- a/components/haptics/index.js
+++ b/components/haptics/index.js
@@ -26,33 +26,23 @@ AFRAME.registerComponent('haptics', {
 
     this.callPulse = function () { self.pulse(); };
 
+    var doInit = function (gamepad) {
+      self.gamepad = gamepad;
+      if (self.gamepad.gamepad) {
+        // WebXR.
+         self.gamepad = self.gamepad.gamepad;
+       }
+       if (!self.gamepad || !self.gamepad.hapticActuators ||
+       !self.gamepad.hapticActuators.length) { return; }
+       self.addEventListeners();
+    };
+
     // There may exist a tracked-controls when this component is initialized
     if (this.el.components['tracked-controls'] && this.el.components['tracked-controls'].controller) {
-      this.gamepad = this.el.components['tracked-controls'].controller;
-
-      if (this.gamepad.gamepad) {
-        // WebXR.
-        this.gamepad = this.gamepad.gamepad;
-      }
-
-      if (!this.gamepad || !this.gamepad.hapticActuators ||
-          !this.gamepad.hapticActuators.length) { return; }
-      this.addEventListeners();
+      doInit(this.el.components['tracked-controls'].controller);
     } else {
       this.el.addEventListener('controllerconnected', function init () {
-        // controllerconntected implies we have a tracked-controls component
-        setTimeout(function () {
-          self.gamepad = self.el.components['tracked-controls'].controller;
-
-          if (self.gamepad.gamepad) {
-            // WebXR.
-            self.gamepad = self.gamepad.gamepad;
-          }
-
-          if (!self.gamepad || !self.gamepad.hapticActuators ||
-              !self.gamepad.hapticActuators.length) { return; }
-          self.addEventListeners();
-        }, 150);
+        doInit(self.el.components['tracked-controls'].controller);
       });
     }
   },

--- a/components/haptics/index.js
+++ b/components/haptics/index.js
@@ -40,10 +40,7 @@ AFRAME.registerComponent('haptics', {
       this.addEventListeners();
     } else {
       this.el.addEventListener('controllerconnected', function init () {
-        // If no tracked-controls yet exists, add it here
-        if (!self.el.components['tracked-controls']) {
-          self.el.setAttribute('tracked-controls', {});
-        }
+        // controllerconntected implies we have a tracked-controls component
         setTimeout(function () {
           self.gamepad = self.el.components['tracked-controls'].controller;
 

--- a/components/haptics/package.json
+++ b/components/haptics/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aframe-haptics-component",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A controller haptics (vibrations) component for A-Frame.",
   "main": "index.js",
   "cdn": "dist/aframe-haptics-component.min.js",

--- a/components/thumb-controls/index.js
+++ b/components/thumb-controls/index.js
@@ -221,7 +221,7 @@ AFRAME.registerComponent('thumb-controls-debug', {
     if (!data.enabled && !AFRAME.utils.getUrlParameter('debug-thumb')) { return; }
     console.log('%c debug-thumb', 'background: #111; color: red');
 
-    var GetTrackedControlsProperties = function () {
+    var getTrackedControlsProperties = function () {
       // Stub.
       el.components['tracked-controls'].handleAxes = () => {};
 
@@ -233,11 +233,11 @@ AFRAME.registerComponent('thumb-controls-debug', {
 
     // There may exist a tracked-controls when this component is initialized
     if (el.components['tracked-controls']) {
-      GetTrackedControlsProperties();
+      getTrackedControlsProperties();
     } else {
       this.el.addEventListener('controllerconnected', function init () {
         // controllerconntected implies we have a tracked-controls component
-        GetTrackedControlsProperties();
+        getTrackedControlsProperties();
       });
     }
 

--- a/components/thumb-controls/index.js
+++ b/components/thumb-controls/index.js
@@ -38,8 +38,6 @@ var SIZE = 240;
  * `thumbdownend`
  */
 AFRAME.registerComponent('thumb-controls', {
-  dependencies: ['tracked-controls'],
-
   schema: {
     thresholdAngle: {default: 89.5},
     thresholdPad: {default: 0.05},
@@ -65,7 +63,18 @@ AFRAME.registerComponent('thumb-controls', {
       this.type = TYPE_PAD;
     });
 
-    this.axis = el.components['tracked-controls'].axis;
+    // There may exist a tracked-controls when this component is initialized
+    if (el.components['tracked-controls']) {
+      this.axis = el.components['tracked-controls'].axis;
+    } else {
+      this.el.addEventListener('controllerconnected', function init () {
+        // If no tracked-controls yet exists, add it here
+        if (!self.el.components['tracked-controls']) {
+          self.el.setAttribute('tracked-controls', {});
+        }
+        this.axis = el.components['tracked-controls'].axis;
+      }
+    }
   },
 
   play: function () {
@@ -136,6 +145,8 @@ AFRAME.registerComponent('thumb-controls', {
   getDistance: function () {
     var axis = this.axis;
 
+    if (!this.axis) { return 0; }
+
     // this.axis comes from the tracked-controls component, which copies it from this.controller.gamepad.axes.
     // See https://immersive-web.github.io/webxr-gamepads-module/#xr-standard-gamepad-mapping
     // for an explanation of gamepad.axes.
@@ -182,6 +193,8 @@ AFRAME.registerComponent('thumb-controls', {
     var angle;
     var axis = this.axis;
 
+    if (!this.axis) { return 0; }
+
     // See comments in getDistance() about axis.
     if (this.type === TYPE_PAD) {
       angle = Math.atan2(-axis[1], axis[0]);
@@ -194,7 +207,7 @@ AFRAME.registerComponent('thumb-controls', {
 });
 
 AFRAME.registerComponent('thumb-controls-debug', {
-  dependencies: ['thumb-controls', 'tracked-controls'],
+  dependencies: ['thumb-controls'],
 
   schema: {
     controllerType: {type: 'string'},
@@ -213,13 +226,28 @@ AFRAME.registerComponent('thumb-controls-debug', {
     if (!data.enabled && !AFRAME.utils.getUrlParameter('debug-thumb')) { return; }
     console.log('%c debug-thumb', 'background: #111; color: red');
 
-    // Stub.
-    el.components['tracked-controls'].handleAxes = () => {};
+    var GetTrackedControlsProperties = function () {
+      // Stub.
+      el.components['tracked-controls'].handleAxes = () => {};
 
-    axis = [0, 0, 0];
-    axisMoveEventDetail = {axis: axis};
-    el.components['tracked-controls'].axis = axis;
-    el.components['thumb-controls'].axis = axis;
+      axis = [0, 0, 0];
+      axisMoveEventDetail = {axis: axis};
+      el.components['tracked-controls'].axis = axis;
+      el.components['thumb-controls'].axis = axis;
+    };
+
+    // There may exist a tracked-controls when this component is initialized
+    if (el.components['tracked-controls']) {
+      GetTrackedControlsProperties();
+    } else {
+      this.el.addEventListener('controllerconnected', function init () {
+        // If no tracked-controls yet exists, add it here
+        if (!self.el.components['tracked-controls']) {
+          self.el.setAttribute('tracked-controls', {});
+        }
+        GetTrackedControlsProperties();
+      }
+    }
 
     canvas = this.createCanvas();
 

--- a/components/thumb-controls/index.js
+++ b/components/thumb-controls/index.js
@@ -52,9 +52,20 @@ AFRAME.registerComponent('thumb-controls', {
     this.directionStick = '';
     this.directionTrackpad = '';
 
+    // There may exist a tracked-controls when this component is initialized
+    if (el.components['tracked-controls']) {
+      this.axis = el.components['tracked-controls'].axis;
+    }
+
     // Get thumb type (stick vs pad).
     this.type = TYPE_STICK;
     el.addEventListener('controllerconnected', evt => {
+      // If no tracked-controls yet exists, add it here
+      if (!self.el.components['tracked-controls']) {
+        self.el.setAttribute('tracked-controls', {});
+      }
+      this.axis = el.components['tracked-controls'].axis;
+
       if (evt.detail.name === 'oculus-touch-controls' ||
           evt.detail.name === 'windows-motion-controls') {
         this.type = TYPE_STICK;
@@ -62,19 +73,6 @@ AFRAME.registerComponent('thumb-controls', {
       }
       this.type = TYPE_PAD;
     });
-
-    // There may exist a tracked-controls when this component is initialized
-    if (el.components['tracked-controls']) {
-      this.axis = el.components['tracked-controls'].axis;
-    } else {
-      this.el.addEventListener('controllerconnected', function init () {
-        // If no tracked-controls yet exists, add it here
-        if (!self.el.components['tracked-controls']) {
-          self.el.setAttribute('tracked-controls', {});
-        }
-        this.axis = el.components['tracked-controls'].axis;
-      }
-    }
   },
 
   play: function () {
@@ -246,7 +244,7 @@ AFRAME.registerComponent('thumb-controls-debug', {
           self.el.setAttribute('tracked-controls', {});
         }
         GetTrackedControlsProperties();
-      }
+      });
     }
 
     canvas = this.createCanvas();

--- a/components/thumb-controls/index.js
+++ b/components/thumb-controls/index.js
@@ -60,10 +60,7 @@ AFRAME.registerComponent('thumb-controls', {
     // Get thumb type (stick vs pad).
     this.type = TYPE_STICK;
     el.addEventListener('controllerconnected', evt => {
-      // If no tracked-controls yet exists, add it here
-      if (!self.el.components['tracked-controls']) {
-        self.el.setAttribute('tracked-controls', {});
-      }
+      // controllerconntected implies we have a tracked-controls component
       this.axis = el.components['tracked-controls'].axis;
 
       if (evt.detail.name === 'oculus-touch-controls' ||
@@ -239,10 +236,7 @@ AFRAME.registerComponent('thumb-controls-debug', {
       GetTrackedControlsProperties();
     } else {
       this.el.addEventListener('controllerconnected', function init () {
-        // If no tracked-controls yet exists, add it here
-        if (!self.el.components['tracked-controls']) {
-          self.el.setAttribute('tracked-controls', {});
-        }
+        // controllerconntected implies we have a tracked-controls component
         GetTrackedControlsProperties();
       });
     }

--- a/components/thumb-controls/package.json
+++ b/components/thumb-controls/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aframe-thumb-controls-component",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "An A-Frame component that provides and normalizes directional events for thumbpads and thumbsticks.",
   "main": "index.js",
   "unpkg": "dist/aframe-thumb-controls-component.min.js",


### PR DESCRIPTION
Should enable generic controls. Previously the tracked-controls dependency would be added before generic controls and thus it would NOT set its controller properties when the controller was detected. Moving the tracked-controls addition to an event allows generic controls to set its properties, and thus the controller is correctly tracked.