### PR TITLE
Update intersection-spawn.js to resolve voxel placement issue

### DIFF
--- a/scenes/aincraft/components/intersection-spawn.js
+++ b/scenes/aincraft/components/intersection-spawn.js
@@ -18,8 +18,16 @@ AFRAME.registerComponent('intersection-spawn', {
       // Create element.
       const spawnEl = document.createElement('a-entity');
 
-      // Snap intersection point to grid and offset from center.
-      spawnEl.setAttribute('position', evt.detail.intersection.point);
+      // Get normal of the face of intersection and scale it down a bit
+      var normal = evt.detail.intersection.face.normal;
+      normal.multiplyScalar(0.25);
+
+      // Get the position of the intersection and add our scaled normal
+      var position = evt.detail.intersection.point;
+      position.add(normal);
+      
+      // Snap new position to grid and offset from center.
+      spawnEl.setAttribute('position', position);
 
       // Set components and properties.
       Object.keys(data).forEach(name => {


### PR DESCRIPTION
Added scaled normal offset position to fix new voxel placement issue when clicking on the left and back faces of a voxel in Aincraft (new voxel gets same position of the voxel that was clicked on in those cases).