### PR TITLE
Update aframe-animation-timeline-component.js

### DIFF
--- a/components/animation-timeline/dist/aframe-animation-timeline-component.js
+++ b/components/animation-timeline/dist/aframe-animation-timeline-component.js
@@ -54,7 +54,9 @@
 	    loop: {
 	      default: 0,
 	      parse: function (value) {
-	        // Boolean or integer.
+	        // boolean
+			if(typeof value === 'boolean'){ return value; }
+			// String or integer.
 	        if (value === 'true') { return true; }
 	        if (value === 'false') { return false; }
 	        return parseInt(value, 10);


### PR DESCRIPTION
Bug:
 - When you try to modify the loop property value via script, if you set the value to true (boolean type), the result is loop = NaN
Expected Behaviour:
 - When you try to modify the loop property value via script, if you set the value to true (boolean type), the result is loop = true.

Solution:
 - Add a validation for the property loop asking if the value provides is already boolean, if it is, then return it without furter actions.