### PR TITLE
[aabb-collider] Be sure parent matrixWorld is up to date before calculating the static box

### DIFF
--- a/components/aabb-collider/index.js
+++ b/components/aabb-collider/index.js
@@ -215,6 +215,7 @@ AFRAME.registerComponent('aabb-collider', {
       if (!el.dataset.aabbColliderDynamic) {
         if (!el.object3D.aabbBox) {
           // Box.
+          el.object3D.updateWorldMatrix(true, false);
           el.object3D.aabbBox = new THREE.Box3().setFromObject(el.object3D);
           // Center.
           el.object3D.boundingBoxCenter = new THREE.Vector3();


### PR DESCRIPTION
Calculating the static box that is only done once may be wrong if parent `matrixWorld` wasn't up to date. Calling `el.object3D.updateWorldMatrix(true, false);` before `setFromObject` fixes the issue.
Please note that `el.object3D.updateWorldMatrix(false, false);` is executed for the a-sphere and children already in the `setFromObject` function.

For example if you put a a-sphere as a child of a a-entity:

```
<a-entity position="3 0 0">
  <a-sphere radius="1" class="collidable"></a-sphere>
</a-entity>
<a-entity hand-controls="right" aabb-collider="objects: .collidable"></a-entity>
```
Without the fix, box.max will be 1 1 1. With the fix it will be properly of 4 1 1.