### PR TITLE
[event-set] Remove redundant removeEventListener() call in remove()

### DIFF
--- a/components/event-set/index.js
+++ b/components/event-set/index.js
@@ -26,10 +26,6 @@ AFRAME.registerComponent('event-set', {
     this.addEventListener();
   },
 
-  remove: function () {
-    this.removeEventListener();
-  },
-
   pause: function () {
     this.removeEventListener();
   },


### PR DESCRIPTION
Remove redundant `removeEventListener()` call in `remove()`, `remove()` is already executing `pause()`