### PR TITLE
Update aabb-collider version in README

### DIFF
--- a/components/aabb-collider/README.md
+++ b/components/aabb-collider/README.md
@@ -49,8 +49,8 @@ Install and use by directly including the [browser files](dist):
 ```html
 <head>
   <title>My A-Frame Scene</title>
-  <script src="https://aframe.io/releases/0.9.0/aframe.min.js"></script>
-  <script src="https://unpkg.com/aframe-aabb-collider-component@3.1.0/dist/aframe-aabb-collider-component.min.js"></script>
+  <script src="https://aframe.io/releases/1.4.2/aframe.min.js"></script>
+  <script src="https://unpkg.com/aframe-aabb-collider-component@3.2.2/dist/aframe-aabb-collider-component.min.js"></script>
 </head>
 
 <body>

--- a/components/aabb-collider/README.md
+++ b/components/aabb-collider/README.md
@@ -31,6 +31,13 @@ presumed to be static for performance purposes.
 | hitclosest      | Intersection between the box and the closest entity from its center. Only one entity is "closest" at a time.           |
 | hitclosestclear | The previously closest intersected entity to the box is no longer the closest entity.                                  |
 
+When the event is emitted on the entity having the aabb-collider component, the event includes detail:
+
+- `hitstart`: `evt.detail.intersectedEls`
+- `hitend`: no detail
+- `hitclosest`: `evt.detail.el`
+- `hitclosestclear`: `evt.detail.el`
+
 #### Members
 
 Accessed via `entity.components['aabb-collider'][<member>]`.

--- a/components/aabb-collider/examples/basic/index.html
+++ b/components/aabb-collider/examples/basic/index.html
@@ -4,9 +4,9 @@
     <meta charset="utf-8">
     <title>A-Frame AABB Collider Component - Basic</title>
     <meta name="description" content="Basic example for AABB Collider component."></meta>
-    <script src="https://aframe.io/releases/0.9.2/aframe.js"></script>
-    <script src="https://unpkg.com/aframe-environment-component@1.0.0/dist/aframe-environment-component.min.js"></script>
-    <script src="https://unpkg.com/aframe-event-set-component@4.0.1/dist/aframe-event-set-component.js"></script>
+    <script src="https://aframe.io/releases/1.4.2/aframe.js"></script>
+    <script src="https://unpkg.com/aframe-environment-component@1.3.3/dist/aframe-environment-component.min.js"></script>
+    <script src="https://unpkg.com/aframe-event-set-component@5.0.0/dist/aframe-event-set-component.js"></script>
     <script src="../../dist/aframe-aabb-collider-component.js"></script>
     <script src="../lib/DragControls.js"></script>
     <script>


### PR DESCRIPTION
Update aabb-collider version in README and use latest aframe and components in the example.