### PR TITLE
[layout] Remove dependencies

### DIFF
--- a/components/layout/package.json
+++ b/components/layout/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/supermedium/superframe/tree/components/layout#readme",
   "devDependencies": {
+    "aframe": "*",
     "browserify": "^12.0.1",
     "budo": "^7.1.0",
     "chai": "^3.4.1",
@@ -37,6 +38,7 @@
     "karma": "^0.13.15",
     "karma-browserify": "^4.4.2",
     "karma-chai-shallow-deep-equal": "0.0.4",
+    "karma-chrome-launcher": "^2.2.0",
     "karma-firefox-launcher": "^0.1.7",
     "karma-mocha": "^0.2.1",
     "karma-mocha-reporter": "^1.1.3",
@@ -45,9 +47,5 @@
     "sinon": "^6.1.0",
     "sinon-chai": "^3.2.0",
     "webpack": "^1.14.0"
-  },
-  "dependencies": {
-    "aframe": "^0.8.2",
-    "karma-chrome-launcher": "^2.2.0"
   }
 }


### PR DESCRIPTION
No need to install karma-chrome-launcher when we consume the layout component as a npm dependency.